### PR TITLE
use Fava release; fix PyGObject dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,13 @@ authors = ["johannesjh <johannesjh@users.noreply.github.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-#fava = "^1.17"
-fava = { git = "https://github.com/johannesjh/fava.git", branch = "setup-with-fe-build" }
+fava = "^1.18"
+PyGObject = "^3.38.0"
 
 [tool.poetry.extras]
 smart-importer = ["smart-importer"]
 
 [tool.poetry.dev-dependencies]
-PyGObject = "^3.38.0"
 pytest = "^5.2"
 pre-commit = "^2.9.2"
 pyclean = "^2.0.0"


### PR DESCRIPTION
PyGObject was only in the list of dev-dependencies, but it's really a
runtime dependency of fava-gtk